### PR TITLE
Fix histogram computation

### DIFF
--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -131,21 +131,39 @@ end
 # of bins
 function histdata(s,bins)
     # When adding an element s to a bin, we use an iequality m < s <= M.
-    # In order to account for elements s==m, we need to artificially reduce
-    # m a tiny bit. Note that this cannot be changed by using other
-    # inequalities:
-    # m <= s < M -- we'd have to increase M to account for s==M
-    # m <= s <= M -- we'd risk adding s to more than one bin
-    ms = min(s)-eps()
+    # In order to account for elements s==m, we need to special-case
+    # the computation for the first bin
+    ms = min(s)
     Ms = max(s)
+    bins = max(bins, 1)
+    if Ms == ms
+        # compute a "natural" scale
+        g = (10.0^floor(log10(abs(ms)+eps()))) / 2
+        ms, Ms = ms - g, ms + g
+    end
     delta = (Ms-ms)/bins
-    x = ms:delta:Ms
-    y = zeros(length(x))
-    for i in 1:length(x)-1
+    x = Range(float(ms), delta, bins+1) # like ms:delta:Ms but less error-prone
+    y = zeros(bins)
+
+    # this is special-cased because we want to include the minimum in the
+    # first bin
+    y[1] = sum(ms .<= s .<= x[2])
+    for i in 2:length(x)-2
         y[i] = sum(x[i] .< s .<= x[i+1])
     end
-    # We want the left bin to start at ms and the right bin to end at Ms
-    x = x+delta/2
+    # this is special-cased because there is no guarantee that x[end] == Ms
+    # (because of how ranges work)
+    if length(y) > 1 y[end] = sum(x[end-1] .< s .<= Ms) end
+
+    if bins != 1
+        # We want the left bin to start at ms and the right bin to end at Ms
+        x = Range(ms+delta/2, delta, bins)
+    else
+        # add two empty bins on the sides to provide a scale to gnuplot
+        x = Range(ms-delta/2, delta, 3)
+        y = [0.0, y[1], 0.0]
+    end
+
     return x,y
 end
 

--- a/src/gaston_hilvl.jl
+++ b/src/gaston_hilvl.jl
@@ -273,7 +273,7 @@ function histogram(args...)
                 end
                 (x,y) = histdata(y,bins)
                 if norm != 0
-                    delta = x[2] - x[1]
+                    delta = step(x)
                     y = norm*y/(delta*sum(y))
                 end
                 addcoords(x,y,cc)


### PR DESCRIPTION
I found a case where `histogram` was plotting wrong results, so I started fixing it, and while testing I ended up with a number of things which this pull request will hopefully solve:
- the previous implementation had problems due to cases where `ms+eps()==ms`
- handle the case in which all values are equal
- handle the case of a single bin
- avoid some more corner cases (e.g. if `(ms:delta:Ms)[end] != Ms`)
- return the exact number of bins requested (i.e. remove the empty one at the end)

As an example of the first issue (which is the most relevant IMO):

```
julia> 100 + eps() == 100
true
```

which meant that the minimum values were left out from the plot.
Initially, I considered using `nextfloat` and co., but that was turning out to be a messier solution that what I wrote in the end, I believe.

As an example of the other mentioned corner case:

```
julia> (1:1/49:27)[end]
26.999999999999996
```

So e.g. if you requested `1274` bins for some data between `1` and `27` you would miss the `27`s if not careful.

I added comments to the code, as was the case for the original code, explaining the reason behind all the choices. I hope I didn't miss any corner case.
