### PR TITLE
Add

### DIFF
--- a/doc/gastondoc.tex
+++ b/doc/gastondoc.tex
@@ -291,8 +291,10 @@ plotting surfaces. Its format is as follows:
 		\cmd{plot()}.
 	\item The \cmd{x} and \cmd{y} arguments have the same meaning as in
 		\cmd{plot()}.
-	\item The argument \cmd{f|Z} may be either a 2-D matrix \cmd{Z} or a
-		function of \cmd{(x,y)}. If \cmd{Z} is provided, then its element
+	\item The argument \cmd{f|Z} may be a 1-D vector or 2-D matrix \cmd{Z}, or a 
+		function \cmd{f} of \cmd{(x,y)}. If \cmd{Z} is provided as a 1-D vector,
+		then its element \cmd{i} is assumed to be the z-coordinate associated with
+		\cmd{(x[i], x[i])}, while if it is provided as a 2-D matrix, then its element
 		\cmd{i,j} is assumed to be the z-coordinate associated with
 		\cmd{(x[i],y[j])}. If \cmd{f} is provided, then \cmd{x} and \cmd{y} must
 		be provided too, and the function \cmd{meshgrid()} will be used to

--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -11,7 +11,9 @@ export closefigure, closeall, clearfigure, figure, plot, histogram, imagesc,
     set_default_title, set_default_xlabel, set_default_ylabel,
     set_default_zlabel, set_default_box, set_default_axis, set_print_color,
     set_print_fontface, set_print_fontsize, set_print_fontscale,
-    set_print_linewidth, set_print_size, gnuplot_send
+    set_print_linewidth, set_print_size, gnuplot_send,
+    addcoords, addconf, llplot, CurveConf, AxesConf, meshgrid
+
 
 # before doing anything else, verify gnuplot is present on this system
 if !success(`which gnuplot`)

--- a/src/gaston_midlvl.jl
+++ b/src/gaston_midlvl.jl
@@ -22,7 +22,7 @@ function addcoords(x::Coord,y::Coord,Z::Array,conf::CurveConf)
     end
     if neZ
         assert(eltype(Z)<:Real,"Invalid coordinates")
-        assert(1 < ndims(Z) < 4,"Invalid coordinates")
+        assert(1 <= ndims(Z) < 4,"Invalid coordinates")
     end
     # fill missing x, y coordinates when Z is not empty
     if neZ && !nex
@@ -57,7 +57,14 @@ function addcoords(x::Coord,y::Coord,Z::Array,conf::CurveConf)
         if conf.plotstyle == "image" || conf.plotstyle == "rgbimage"
             assert(size(Z,2) == length(x), "Wrong number of columns in Z")
             assert(size(Z,1) == length(y), "Wrong number of rows in Z")
-        else
+        elseif 1 == size(Z,2)
+	  #Assume that we have x = list of x coordinates, y = list of
+	  #y coordinates, z = list of z coordinates. This is ambiguous
+	  #in the case in which we only plot one point, but in that
+	  #case both interpretations give the same result.
+	    assert(size(Z,1) == length(x), "Z and x must have same number of elements")
+	    assert(size(Z,1) == length(y), "Z and y must have same number of elements")
+	else
             assert(size(Z,2) == length(x), "Wrong number of columns in Z")
             assert(size(Z,1) == length(y), "Wrong number of rows in Z")
         end
@@ -92,6 +99,7 @@ function addcoords(x::Coord,y::Coord,Z::Array,conf::CurveConf)
     end
     gnuplot_state.figs[c] = fig
 end
+
 addcoords(y) = addcoords(1:length(y),y,[],CurveConf())
 addcoords(y,c::CurveConf) = addcoords(1:length(y),y,[],c)
 addcoords(x,y) = addcoords(x,y,[],CurveConf())
@@ -271,13 +279,19 @@ function llplot()
         # create data file
         f = open(filename,"w")
         for i in figs[c].curves
+          if size(i.Z,2) == 1 #lists of coordinates
+	    for j in 1:length(i.x)
+	      writedlm(f,[i.x[j] i.y[j] i.Z[j]],' ')
+	    end
+	  else
             for row in 1:length(i.x)
                 for col in 1:length(i.y)
                     writedlm(f,[i.x[row] i.y[col] i.Z[row,col]],' ')
                 end
                 write(f,"\n")
             end
-            write(f,"\n\n")
+	  end
+          write(f,"\n\n")
         end
         close(f)
         # send figure configuration to gnuplot

--- a/src/gaston_midlvl.jl
+++ b/src/gaston_midlvl.jl
@@ -58,8 +58,8 @@ function addcoords(x::Coord,y::Coord,Z::Array,conf::CurveConf)
             assert(size(Z,2) == length(x), "Wrong number of columns in Z")
             assert(size(Z,1) == length(y), "Wrong number of rows in Z")
         else
-            assert(size(Z,1) == length(x), "Wrong number of columns in Z")
-            assert(size(Z,2) == length(y), "Wrong number of rows in Z")
+            assert(size(Z,2) == length(x), "Wrong number of columns in Z")
+            assert(size(Z,1) == length(y), "Wrong number of rows in Z")
         end
     else
         assert(length(x) == length(y),


### PR DESCRIPTION
1. Export midlevel functions. These are described in the manual, so it seems sensible that they be exported.
2. Switch error message in check  on Z matrix in add-coords to conform to (what I understand to be) the usual convention.
3. Change addcoords and llplot so that surf can plot lists of points, sort of like Mathematica's ListPlot3D: e.g. surf([1:10], [1:10], [1:10].^2, "plotstyle", "points")