### PR TITLE
Added qt terminal

### DIFF
--- a/doc/gastondoc.tex
+++ b/doc/gastondoc.tex
@@ -146,14 +146,14 @@ This function always returns the handle of the current figure.
 \subsection{Terminals}
 
 Gaston supports plotting to the screen as well as printing the plots to files.
-Three screen terminals are supported: \cmd{wxt}, \cmd{x11} and
+Three screen terminals are supported: \cmd{wxt}, \cmd{qt}, \cmd{x11} and
 \cmd{aqua}\footnote{Gnuplot provides the \cmd{aqua} terminal on Mac OS X
 systems only. It is included in Gaston for convenience of users of that system.
 However, the author does not have access to any Mac computers and, in
 consequence, this terminal should be considered as unsupported. Bug reports,
 patches and comments are welcome, as always.}. The \cmd{x11} terminal is faster
-than \cmd{wxt}, but it offers lower plot quality; it is provided for use in
-systems with lower performance or that don't support WxWindows.
+than \cmd{wxt} or \cmd{qt}, but it offers lower plot quality; it is provided for
+use in systems with lower performance or that don't support WxWindows.
 
 For printing to files, terminals \cmd{svg}, \cmd{pdf}, \cmd{png}, \cmd{eps} and
 \cmd{gif} are supported. For more details on printing, see section

--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -318,7 +318,7 @@ end
 
 # Validate terminal type.
 function validate_terminal(s::String)
-    supp_terms = ["wxt", "x11", "svg", "gif", "png", "pdf", "aqua", "eps"]
+    supp_terms = ["qt", "wxt", "x11", "svg", "gif", "png", "pdf", "aqua", "eps"]
     if s == "aqua" && OS_NAME != :Darwin
         return false
     end
@@ -330,7 +330,7 @@ end
 
 # Identify terminal by type: file or screen
 function is_term_screen(s::String)
-    screenterms = ["wxt", "x11", "aqua"]
+    screenterms = ["qt", "wxt", "x11", "aqua"]
     if in(s, screenterms)
         return true
     end


### PR DESCRIPTION
In newer versions of Ubuntu, the `wxt` terminal has been replaced with a `qt` terminal.
I added `qt` to the available terminals, so at least it can be used with `set_terminal`, even though it needs to be set explicitly.
I'm not sure whether this depends on compilation options, or when it was introduced, or how to test which terminal is available. So for now this is a band aid.
Any objections to merging this for the time being?