### PR TITLE
Initialize the gnuplot pipe on package loading

### DIFF
--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -41,4 +41,6 @@ finalizer(gnuplot_state,gnuplot_exit)
 # global variable that stores Gaston's configuration
 gaston_config = GastonConfig()
 
+gnuplot_init()
+
 end


### PR DESCRIPTION
The issue #56 can be solved if the gnuplot initialization is made prior the execution of `gnuplot_send()`