### PR TITLE
improve handling of tempdir()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 julia:
-  - 0.5
+  - 0.6
 os:
   - linux
 notifications:

--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -306,9 +306,9 @@ function termstring(term::AbstractString)
             s = "$s size $(gc.print_size)"
         end
         if gnuplot_state.isjupyter
-			ts = "$s \nset output\"$(gc.jupyterfile)\""
+			ts = "$s \nset output '$(gc.jupyterfile)'"
 		else
-			ts = "$s \nset output \"$(gc.outputfile)\""
+			ts = "$s \nset output '$(gc.outputfile)'"
 		end
     end
     return ts

--- a/src/gaston_config.jl
+++ b/src/gaston_config.jl
@@ -52,7 +52,7 @@ function GastonConfig()
 		# output file name
 		"",
 		# IJulia file name
-		"$(tempdir())/gaston-ijulia.png",
+        joinpath(tempdir(), "gaston-ijulia.png"),
 		# print parameters
 		"color", "Sans", 12, 0.5, 1, "640,480",
 		# tmp file prefix

--- a/src/gaston_llplot.jl
+++ b/src/gaston_llplot.jl
@@ -34,7 +34,7 @@ function llplot(gpcom="")
     # Datafile filename. This is where we store the coordinates to plot.
     # This file is then read by gnuplot to do the actual plotting. One file
     # per figure handle is used; this avoids polutting /tmp with too many files.
-    filename = "$(tempdir())/gaston-$(gaston_config.tmpprefix)-$(fig.handle)"
+    filename = joinpath(tempdir(), "gaston-$(gaston_config.tmpprefix)-$(fig.handle)")
 	f = open(filename,"w")
 
     # Send appropriate coordinates and data to gnuplot, depending on


### PR DESCRIPTION
I had problems with using Gaston.jl on Jupyter notebook under Windows.
Here are minor things improving on it:
* use `joinpath` to create path to a created file - earlier `/` was used which is not a standard Windows escape (also the difference is that under Windows `tempdir()` returns string ending in `\`)
* ~~add a comment of possible problems with creation of temporary plot by `gnuplot` for later use by Jupyter notebook (this is something that has to be fixed by a user but I think it is worth to comment on this)~~ EDIT: actually it is enough to change quoting from `"" to `'` in `output` setting to fix the problems. I have squashed all commits in this PR.
  