### PR TITLE
Fix version checking

### DIFF
--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -11,8 +11,10 @@ export closefigure, closeall, figure,
 import Base.show
 
 # before doing anything else, verify gnuplot is present on this system
-if !success(`gnuplot --version`)
-    error("Gaston cannot be loaded: gnuplot is not available on this system.")
+try
+  success(`gnuplot --version`)
+catch
+  error("Gaston cannot be loaded: gnuplot is not available on this system.")
 end
 
 # load files


### PR DESCRIPTION
The success function does not return false when the argument fails. It raises and exception that must be caught to correctly display the error message.