### PR TITLE
Explicit __precompile__(false) to make v0.7 work

### DIFF
--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -2,6 +2,7 @@
 ##
 ## This file is distributed under the 2-clause BSD License.
 
+__precompile__(false)
 module Gaston
 
 export closefigure, closeall, figure,


### PR DESCRIPTION
For Julia v0.7 and v1.0 __precompile__(true) is the default, so now we need to be explicit that the module should not be precompiled.