### PR TITLE
Fix `warn` and `is_windows`

### DIFF
--- a/src/gaston_config.jl
+++ b/src/gaston_config.jl
@@ -155,7 +155,7 @@ function set(;legend         = gaston_config.legend,
     gaston_config.print_size        = print_size
     # don't change terminal inside jupyter
     if terminal != "ijulia" && gnuplot_state.isjupyter
-        warn("Terminal cannot be changed in a Jupyter notebook.")
+        @warn("Terminal cannot be changed in a Jupyter notebook.")
     else
         gaston_config.terminal = terminal
     end

--- a/src/gaston_llplot.jl
+++ b/src/gaston_llplot.jl
@@ -179,7 +179,7 @@ function llplot()
             err = take!(ChanStdErr)
             gnuplot_state.gp_lasterror = err
             gnuplot_state.gp_error = true
-            warn("Gnuplot returned an error message:\n  $err)")
+            @warn("Gnuplot returned an error message:\n  $err)")
         else
             while true
                 stdout_count = stdout_count + 1
@@ -232,7 +232,7 @@ function llplot()
                 # Gnuplot met trouble while plotting.
                 gnuplot_state.gp_lasterror = err
                 gnuplot_state.gp_error = true
-                warn("Gnuplot returned an error message:\n  $err)")
+                @warn("Gnuplot returned an error message:\n  $err)")
             end
         else
             sleep(sleep_interval)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,7 +183,7 @@ end
               printfigure(term="svg")
               Gaston.gnuplot_state.gp_error
           end == false
-if !is_windows()
+if !Sys.iswindows()
     @test begin
               printfigure(term="gif")
               Gaston.gnuplot_state.gp_error
@@ -221,7 +221,7 @@ end
     @test set(zlabel="A") == nothing
     @test set(fill="solid") == nothing
     @test set(grid="on") == nothing
-    if !is_windows()
+    if !Sys.iswindows()
         @test set(terminal="x11") == nothing # This test does not pass in Windows
     end
     @test set(terminal="x11") == nothing


### PR DESCRIPTION
Closes #94

This pull request fixes the two issues mentioned in #94.

Together with #96 and #97 this will make Gaston work in `Julia>0.7` again.

This pull request together with #96 and #97 have been added to the `fix-1.0` branch in my [fork](https://github.com/cosama/Gaston.jl) and can be checked out and tested in `julia` with:

```
using Pkg
Pkg.add(Pkg.PackageSpec(url="https://github.com/cosama/Gaston.jl", rev="fix-1.0"))
using Gaston
```

The tests `Pkg.test("Gaston")` run without any issues with that version.