### PR TITLE
Fix multiplot when first subplot isa Nothing

### DIFF
--- a/src/gaston_types.jl
+++ b/src/gaston_types.jl
@@ -62,6 +62,7 @@ Figure(handle::Int) = Figure(handle=handle)
 
 getindex(f::Figure, args... ; kwargs...) = getindex(f.subplots, args... ; kwargs...)
 
+isempty(f::Nothing) = false
 isempty(f::Figure; subplot = 1) = isempty(f[subplot])
 
 length(f::Figure) = length(f.subplots)


### PR DESCRIPTION
Fixes https://github.com/mbaz/Gaston.jl/issues/167.

Also tested for 3d:
```julia
using Gaston

x, y = [0, 1, 2, 3], [0, 1, 2]
z = [10 10 10 10; 10 5 1 0; 10 10 10 10]
p1 = surf(x, y, z)
x = y = -15:.4:15
f1 = (x, y) -> @. sin(sqrt(x^2 + y^2)) / sqrt(x^2 + y^2)
p2 = surf(x, y, f1, lc = :turquoise, Axes(hidden3d =:on))

plot([nothing p1; p2 nothing])
save(term="png", output="c.png")
```