### PR TITLE
make `save` safer

### DIFF
--- a/src/gaston_llplot.jl
+++ b/src/gaston_llplot.jl
@@ -106,11 +106,11 @@ end
 function llplot(F::Figure ; printstring=nothing)
     global gnuplot_state
 
-    isempty(F) && return nothing
+    isempty(F) && return false
 
-    config[:mode] == "null" && return nothing
+    config[:mode] == "null" && return false
 
-    gnuplot_state.gnuplot_available || return nothing
+    gnuplot_state.gnuplot_available || return false
 
     gnuplot_send("reset session")
 
@@ -182,6 +182,6 @@ function llplot(F::Figure ; printstring=nothing)
         @warn("Gnuplot returned an error message:\n  $err")
     end
 
-    return nothing
+    return true
 
 end

--- a/src/gaston_llplot.jl
+++ b/src/gaston_llplot.jl
@@ -170,8 +170,15 @@ function llplot(F::Figure ; printstring=nothing)
     # Start reading gnuplot's streams in "background"
     ch_out = async_reader(P.gstdout, config[:timeout])
     out = take!(ch_out)
-    out === :timeout && @warn("Gnuplot is taking too long to respond.")
-    out === :eof     && error("Gnuplot crashed")
+    ok = if out === :timeout
+        @warn("Gnuplot is taking too long to respond.")
+        false
+    elseif out === :eof
+        error("Gnuplot crashed")
+        false
+    else
+        true
+    end
 
     # check for errors while plotting
     yield()
@@ -182,6 +189,6 @@ function llplot(F::Figure ; printstring=nothing)
         @warn("Gnuplot returned an error message:\n  $err")
     end
 
-    return true
+    return ok
 
 end

--- a/src/gaston_save.jl
+++ b/src/gaston_save.jl
@@ -7,6 +7,8 @@
 
 Save current figure (or figure specified by `handle`) using the specified `term`. Optionally,
 the font, size, linewidth, and background may be specified as arguments.
+
+Returns `true` in any gnuplot command have been sent else `false`.
 """
 function save(; term::String,
                 output::String,
@@ -43,7 +45,5 @@ function save(; term::String,
     end
 
     # send gnuplot commands
-    llplot(fig, printstring=(pc,output))
-
-    return nothing
+    return llplot(fig, printstring=(pc,output))
 end

--- a/src/gaston_types.jl
+++ b/src/gaston_types.jl
@@ -63,7 +63,8 @@ Figure(handle::Int) = Figure(handle=handle)
 getindex(f::Figure, args... ; kwargs...) = getindex(f.subplots, args... ; kwargs...)
 
 isempty(f::Nothing) = false
-isempty(f::Figure; subplot = 1) = isempty(f[subplot])
+isempty(f::Figure; subplot = nothing) =
+    subplot === nothing ? all(isempty, f.subplots) : isempty(f[subplot])
 
 length(f::Figure) = length(f.subplots)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -445,31 +445,19 @@ end
 @testset "Saving plots" begin
     closeall()
     set(reset=true)
-    set(mode="null")
+    # set(mode="null")
     p = plot(1:10)
     filename = tempname()
-    @test begin
-        save(output=filename,term="pdf")
-    end == nothing
-    @test begin
-        save(handle=1,term="png",output=filename)
-    end == nothing
-    @test begin
-        save(term="eps",output=filename)
-    end == nothing
-    @test begin
-        save(term="pdf",
+    @test save(output=filename,term="pdf")
+    @test save(handle=1,term="png",output=filename)
+    @test save(term="eps",output=filename)
+    @test save(term="pdf",
              output=filename,
              font = "Arial, 12",
              size = "5,3",
              linewidth = 3)
-    end == nothing
-    @test begin
-        save(term="svg",output=filename,linewidth=3)
-    end == nothing
-    @test begin
-        save(term="gif",output=filename,size="640,480")
-    end == nothing
+    @test save(term="svg",output=filename,linewidth=3)
+    @test save(term="gif",output=filename,size="640,480")
 end
 
 @testset "Tests that should fail" begin


### PR DESCRIPTION
@mbaz, `llplot` can return earlier if no command has been sent.
Hence, any method waiting for a file to be written on the disk might deadlock on `save` early return (see https://github.com/JuliaPlots/Plots.jl/blob/master/src/backends/gaston.jl#L72-L73).

- return a boolean to avoid entering a deadlock;
- fix the definition of `isempty` (by default an empty figure means all the subplots being empty, not just the first one);
- adjust tests.

A version bump would be appreciated.
Needed for https://github.com/JuliaPlots/Plots.jl/pull/4553 (failing example disabled for now).
Local tests pass.