### PR TITLE
fix parsing on 1.6 - add ci checks

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,20 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  contents: write
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Ubuntu LaTeX dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install gnuplot
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,3 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-processcoverage@latest
-      - uses: codecov/codecov-action@v3
-        with:
-          file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+   branches: [master]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'  # latest LTS
+          - '1'
+          - 'nightly'
+        os: [ubuntu-latest]
+        arch: [x64]
+        include:  # spare windows/macos CI credits
+          - os: windows-latest
+            version: '1'
+            arch: x64
+          - os: macOS-latest
+            version: '1'
+            arch: x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@latest
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,7 @@ jobs:
           - 'nightly'
         os: [ubuntu-latest]
         arch: [x64]
-        include:  # spare windows/macos CI credits
-          - os: windows-latest
-            version: '1'
-            arch: x64
-          - os: macOS-latest
-            version: '1'
-            arch: x64
+
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 ColorSchemes = "^3.9"
-julia = "^1.3"
+julia = "^1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -83,8 +83,10 @@ function __init__()
     end
 
     if gnuplot_state.gnuplot_available
-        ver_str = chomp(read(`gnuplot --version`, String)) |> String
-        ver_str = replace(ver_str, "gnuplot " => "", "patchlevel " => "", "." => " ")
+        ver_str = chomp(read(`gnuplot --version`, String))
+        for pair in ("gnuplot " => "", "patchlevel " => "", "." => " ")
+            ver_str = replace(ver_str, pair)
+        end
         GNUPLOT_VERSION = VersionNumber(parse.(Int, split(ver_str, " "))...)
         @assert GNUPLOT_VERSION > v"1"
         gstdin = Pipe()

--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -83,7 +83,8 @@ function __init__()
     end
 
     if gnuplot_state.gnuplot_available
-        ver_str = replace(chomp(read(`gnuplot --version`, String)), "gnuplot " => "", "patchlevel " => "", "." => " ")
+        ver_str = chomp(read(`gnuplot --version`, String)) |> String
+        ver_str = replace(ver_str, "gnuplot " => "", "patchlevel " => "", "." => " ")
         GNUPLOT_VERSION = VersionNumber(parse.(Int, split(ver_str, " "))...)
         @assert GNUPLOT_VERSION > v"1"
         gstdin = Pipe()


### PR DESCRIPTION
@mbaz, having no CI is a mistake: https://github.com/mbaz/Gaston.jl/pull/179 introduced a bug on older julia release (e.g. lts 1.6), and this typically something to be caught by ci.

- add ci workflow;
- fix parsing on 1.6.

For https://github.com/JuliaPlots/Plots.jl/pull/4609.

A version bump would be appreciated after ci is green.