### PR TITLE
do not run i/o when precompiling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Gaston"
 uuid = "4b11ee91-296f-5714-9832-002c20994614"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -68,6 +68,7 @@ end
 # initialize gnuplot
 function __init__()
     global P, gnuplot_state, GNUPLOT_VERSION
+    ccall(:jl_generating_output, Cint, ()) == 1 && return
 
     gnuplot_state.gnuplot_available = false
 


### PR DESCRIPTION
Fix issue when precompiling extensions:
```
This means that a package has started a background task or event source that has not finished running. For precompilation to complete successfully, the event source needs to be closed explicitly. See the developer documentation on fixing precompilation hangs for more help.
```

A version bump would be appreciated.

Needed for https://github.com/JuliaPlots/Plots.jl/pull/4904.