### PR TITLE
run ci on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
 
     steps:
       - run: sudo apt-get -y install gnuplot
+        if: startsWith(matrix.os, 'ubuntu')
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:


### PR DESCRIPTION
@mbaz, CI should also run on PRs.

In order to prepare https://github.com/mbaz/Gaston.jl/pull/187, also run on all OSs (windows, macos).

Also, test `pre` on `ubuntu` to detect potential upstream issues.