### PR TITLE
fix `GNUPLOT_DRIVER_DIR`

### DIFF
--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -11,7 +11,7 @@
 const gnuplot_binary = Preferences.load_preference(Gaston, "gnuplot_binary", "artifact")
 
 const max_lines = string(typemax(Int32) - 1_000)
-const magic = "_Gaston_"
+const magic = "Gaston-4b11ee91-296f-5714-9832-002c20994614"
 
 function gnuplot_path()
     return if gnuplot_binary in ("artifact", "jll")

--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -15,7 +15,7 @@ const magic = "_Gaston_"
 
 function gnuplot_path()
     return if gnuplot_binary in ("artifact", "jll")
-        addenv(Gnuplot_jll.gnuplot(), "LINES" => max_lines, "GNUPLOT_DRIVER_DIR" => dirname(Gnuplot_jll.gnuplot_qt_path))
+        addenv(Gnuplot_jll.gnuplot(), "LINES" => max_lines, "GNUPLOT_DRIVER_DIR" => dirname(Gnuplot_jll.gnuplot_fake_path))
     elseif Sys.isexecutable(gnuplot_binary)
         addenv(Cmd([gnuplot_binary]), "LINES" => max_lines)
     else

--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -10,7 +10,7 @@
 # the cache will not invalidate when preferences change
 const gnuplot_binary = Preferences.load_preference(Gaston, "gnuplot_binary", "artifact")
 
-const max_lines = string(typemax(Int32) - 1_000)
+const max_lines = string(typemax(Int32) ÷ 2)
 const magic = "Gaston-4b11ee91-296f-5714-9832-002c20994614"
 
 function gnuplot_path()

--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -15,7 +15,7 @@ const magic = "_Gaston_"
 
 function gnuplot_path()
     return if gnuplot_binary in ("artifact", "jll")
-        addenv(Gnuplot_jll.gnuplot(), "LINES" => max_lines)
+        addenv(Gnuplot_jll.gnuplot(), "LINES" => max_lines, "GNUPLOT_DRIVER_DIR" => dirname(Gnuplot_jll.gnuplot_qt_path))
     elseif Sys.isexecutable(gnuplot_binary)
         addenv(Cmd([gnuplot_binary]), "LINES" => max_lines)
     else

--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -95,7 +95,7 @@ function gp_send(process::Base.Process, message::String)
 
             # handle errors
             process_running(process) || @warn "gnuplot crashed."
-            isempty(gperr) || @info "gnuplot returned a message in STDERR:" gperr
+            isempty(gperr) || @info "gnuplot returned a message in STDERR:$gperr"
 
             return gpout * '\n', gperr * '\n'
         else

--- a/src/gaston_aux.jl
+++ b/src/gaston_aux.jl
@@ -15,7 +15,12 @@ const magic = "_Gaston_"
 
 function gnuplot_path()
     return if gnuplot_binary in ("artifact", "jll")
-        addenv(Gnuplot_jll.gnuplot(), "LINES" => max_lines, "GNUPLOT_DRIVER_DIR" => dirname(Gnuplot_jll.gnuplot_fake_path))
+        addenv(
+            Gnuplot_jll.gnuplot(),
+            "LINES" => max_lines,
+            "PAGER" => nothing,
+            "GNUPLOT_DRIVER_DIR" => dirname(Gnuplot_jll.gnuplot_fake_path)
+        )
     elseif Sys.isexecutable(gnuplot_binary)
         addenv(Cmd([gnuplot_binary]), "LINES" => max_lines)
     else


### PR DESCRIPTION
Needs https://github.com/JuliaPackaging/Yggdrasil/pull/11595.

Fixes https://github.com/mbaz/Gaston.jl/pull/187?notification_referrer_id=NT_kwDOAMzS8LQxNzMxNTg3ODQ5NzoxMzQyMzM0NA#issuecomment-3033782158.

Using this PR, the following works (allows to use interactive terminals such as `gnuplot_qt` or `gnuplot_x11`):
```julia
julia> using Gaston
julia> plot(1:10)
```