### PR TITLE
restore `ci` on `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: ci
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches: [master]
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Why was this removed in https://github.com/mbaz/Gaston.jl/commit/47f94a3c00f7d73eee33a33a7ef2b2e428938aff ?

Running `ci` on `master` is a good practice, and I currently don't see any valid reason to disable it.