### PR TITLE
restore `GNUPLOT_VERSION` for `Plots`

### DIFF
--- a/src/Gaston.jl
+++ b/src/Gaston.jl
@@ -50,6 +50,8 @@ using PrecompileTools
 import Preferences
 import Gnuplot_jll
 
+const GNUPLOT_VERSION = Ref(v"0.0.0")
+
 # URL for web-hosted javascript files, for svg and canvas interactivity
 const JSDIR = "'https://cdn.jsdelivr.net/gh/mbaz/gnuplot-js@1.0/'"
 
@@ -124,7 +126,8 @@ function __init__()
     end
 
     try
-        success(`$(config.exec) --version`)
+        ver_str = replace(read(`$(config.exec) --version`, String), "gnuplot" => "", "patchlevel" => "", "." => " ") |> strip |> split
+        GNUPLOT_VERSION[] = VersionNumber(parse.(Int, ver_str)...)
         state.enabled = true
     catch
         @warn "Gnuplot is not available on this system. Gaston will be unable to produce any plots."

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,10 @@ gh = Gaston.gethandles
 reset = Gaston.reset
 null() = Gaston.config.output = :null
 
+@testset "Gnuplot version" begin
+    @test Gaston.GNUPLOT_VERSION[] ≥ v"6"
+end
+
 @testset "Available terminals" begin
     @test Gaston.terminals() ≡ nothing
 end


### PR DESCRIPTION
Restore https://github.com/mbaz/Gaston.jl/pull/179, which was removed : we need this for `Plots` in order to determine `Int32` or `Int64` behavior for ticks.