### PR TITLE
fix sys gnuplot test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/test/preferences.jl
+++ b/test/preferences.jl
@@ -22,9 +22,10 @@ invalidate_compiled_cache!(m::Module) =  # make sure the compiled cache is remov
     @test run(`$(Base.julia_cmd()) $script`) |> success
 end
 
-Sys.islinux() && @testset "System gnuplot" begin
+const sys_gnuplot = Sys.which("gnuplot")
+
+(Sys.islinux() && sys_gnuplot ≢ nothing) && @testset "System gnuplot" begin
     script = tempname()
-    sys_gnuplot = Sys.which("gnuplot")
     set_preferences!(Gaston, "gnuplot_binary" => sys_gnuplot; force = true)
     invalidate_compiled_cache!(Gaston)
     write(


### PR DESCRIPTION
@mbaz I do'nt understand the purpose of https://github.com/mbaz/Gaston.jl/commit/de67a8f10171c4a3c91fdb27c732138f37b9f38e.

When using `@latest` suffix, this ensure that we use the latest `setup-julia` actions, hence we don't have to manually change numbers e.g. `@v3` to `@v4`.

Fix for https://github.com/mbaz/Gaston.jl/commit/de67a8f10171c4a3c91fdb27c732138f37b9f38e, making the preferences test against the system gnuplot conditional.